### PR TITLE
Travis node versions bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ node_js:
 before_script:
   - sudo apt-get update -qq 
   - sudo apt-get install -qq graphicsmagick
-  - npm install -g bower
-  - bower install
-  - make
 
 services:
   - mongodb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "0.12"
+  - "iojs"
 
 before_script:
   - sudo apt-get update -qq 

--- a/bower.json
+++ b/bower.json
@@ -33,7 +33,7 @@
     "jquery": "2.1.1"
   },
   "resolutions": {
-    "angular": "1.2.26",
+    "angular": "1.2.28",
     "jquery": "2.1.1"
   }
 }


### PR DESCRIPTION
Set travis to run tests on 0.12 and iojs. Also removes bower from travis tasks and persists the angular version to bower.json.