### PR TITLE
[WIP] Update documentation

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,7 @@ pipeline:
       - MONGO_URL=mongodb://database:27017/nit-test
     commands:
       - apt-get update && apt-get install -qq graphicsmagick
-      - make install
+      - make install-deps
       - make jshint
       - make mocha
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN set -e \
   && apt-get update \
   && apt-get -qq install graphicsmagick \
   && apt-get clean \
-  && make install && make
+  && make install-deps && make
 
 VOLUME ["/app/public/images/unions"]
 

--- a/Makefile
+++ b/Makefile
@@ -70,14 +70,11 @@ endif
 jshint:
 	$(JSHINT) .
 
-install:
+install-deps:
 	npm install
 	$(BOWER) install --allow-root
 
-reset:
-	git fetch && git reset --hard origin/master
-
-production: reset install all
+production: install-deps all
 	forever restart $(PWD)/index.js
 
 server:
@@ -95,4 +92,4 @@ lint:
 test:
 	@make lint && make mocha
 
-.PHONY: all clean test server install reset production jshint lint mocha
+.PHONY: all clean test server install-deps production jshint lint mocha

--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,7 @@ Ny i Trondheim is built using [Node.js](http://nodejs.org/), [express](http://ex
 
 To install a fresh clone, you must have node, npm and bower installed then run
 ```bash
-$ make install
+$ make install-deps
 $ make
 ```
 
@@ -15,12 +15,35 @@ The project also relies on [gm](https://github.com/aheckmann/gm), which means yo
 
 In addition you'll need to have MongoDB running. You can set the database information through `export MONGO_URL="mongodb://localhost:PORT/DATABASENAME"`.
 
+For development purposes, the MongoDB database can be started via docker-compose. You can run
+```bash
+$ docker-compose up
+```
+
+to start a MongoDB instance. When using docker-compose, you don't have to explicitly set the `MONGO_URL`
+
+
 When the installation has finished, you can run
 ```bash
 $ make server
 ```
 
 to fire up a development server on [localhost:3000](http://localhost:3000).
+
+## Fixtures
+To load development fixtures, run the following commands
+```bash
+$ node scripts/bootstrap-db unions
+$ node scripts/bootstrap-db articles
+```
+
+For more information about the fixture loading, run
+```bash
+$ node scripts/bootstrap-db -h
+```
+
+The admin user is named `generelt`, and all development unions are loaded with
+the default password `temp`.
 
 ## Build assets (CSS/JS)
 To build JavaScript and CSS files you must run

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+
+services:
+  mongo:
+    image: 'mongo:latest'
+    ports:
+     - '127.0.0.1:27017:27017'


### PR DESCRIPTION
Add support for running MongoDB via docker-compose.

Cleanup in readme.

Rename `make install` to `make install-deps`. In *makefile*-context, `make install` means installing the software to the system, and should not be used to install deps. `make install-deps` could also be replaced completely with `npm install` (with a custom post script). The usual unix way to use makefiles is:
```bash
$ ./configure    # generate makefile
$ make           # compile code
$ make install   # install code to machine, sometimes run as sudo becuase of the --prefix
```

This also removes the `make reset` command that resets your git repo the **hard** way, and therefore has to reason to exist :smile: . 