### PR TITLE
Change docker entrypoint to node index.js

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ RUN set -e \
 
 VOLUME ["/app/public/images/unions"]
 
-ENTRYPOINT ["make", "server"]
+ENTRYPOINT ["node", "index.js"]


### PR DESCRIPTION
The docker image shouldn't watch for file changes, or handle life cycle events. All that is up to the user of the image to handle.