### PR TITLE
[WIP] Add last modified to articles

### DIFF
--- a/app/assets/css/style.styl
+++ b/app/assets/css/style.styl
@@ -75,6 +75,9 @@ h1
     color #fff
     text-decoration none
 
+#last-modified
+  font-size: 13px;
+
 button
   &.wide
     width 100%

--- a/app/assets/js/controllers/page-controller.js
+++ b/app/assets/js/controllers/page-controller.js
@@ -1,12 +1,21 @@
 /**
  * PageController
  */
- 
+
 module.exports = ['$rootScope', '$scope', '$location', '$routeParams', 'articleService', function($rootScope, $scope, $location, $routeParams, articleService) {
   $scope.loading = true;
   $scope.article = {};
 
   $rootScope.title = '';
+  $scope.dateToHumanReadable = function(date) {
+    var mm = date.getMonth() + 1;
+    var dd = date.getDate();
+    return [
+      (dd < 10 ? '0' : '') + dd,
+      (mm < 10 ? '0' : '') + mm,
+      date.getFullYear()
+    ].join('.');
+  };
 
   $scope.update = function() {
     $scope.loading = true;
@@ -15,6 +24,10 @@ module.exports = ['$rootScope', '$scope', '$location', '$routeParams', 'articleS
       articleService.findBySlug(union, $routeParams.articleSlug).success(function(article) {
         $scope.article = article;
         $rootScope.title = $scope.article.title;
+
+        $scope.lastModified = $scope.dateToHumanReadable(
+          new Date(article.lastModified || article.createdAt)
+        );
         $scope.loading = false;
       }).error(function() {
         $scope.article.title = '404';

--- a/app/controllers/articles.js
+++ b/app/controllers/articles.js
@@ -89,6 +89,7 @@ var saveArticle = function(req, res, next) {
   var article;
   if (update) {
     article = _.assign(req.article, req.body);
+    article.lastModified = Date.now();
   } else {
     article = new Article(req.body);
     article.union = req.params.union;

--- a/app/models/article.js
+++ b/app/models/article.js
@@ -49,7 +49,8 @@ var articleSchema = new Schema({
   createdAt: {
     type: Date,
     default: Date.now
-  }
+  },
+  lastModified: Date
 });
 
 articleSchema.pre('save', function(next) {

--- a/app/views/partials/page.jade
+++ b/app/views/partials/page.jade
@@ -3,6 +3,9 @@ nit-loading-indicator
 
 .article-content
   h1 {{article.title}}
+  p(id='last-modified' ng-if='lastModified')
+    span Sist oppdatert:{{' '}}
+    span(ng-bind='lastModified')
 
   p.description
     a(ng-href='/static/images/{{article.image}}', ng-show='article.imageCropped | exists', target='_blank')


### PR DESCRIPTION
Add a `lastModified` value to all article, making it easier to spot old (and therefore wrong) information. This should also be backwards compatible with other versions.

It may be a "bad idea" to merge this now, because all articles will after the update have the current information visible:`Sist oppdaters: "the day they were created"`. It could therefore be merged later this autumn, to avoid showing false information. 

![screenshot from 2017-08-09 18-58-27](https://user-images.githubusercontent.com/1467188/29133933-55725a4c-7d35-11e7-9154-da535e19441e.png)
